### PR TITLE
change the README to reflect the correct installation directory when …

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ https://github.com/robbyrussell/oh-my-zsh/#basic-installation
 
 and execute this :
 
-> $ git clone https://github.com/chmouel/oh-my-zsh-openshift ~/.oh-my-zsh/custom/oc
+> $ git clone https://github.com/chmouel/oh-my-zsh-openshift ~/.oh-my-zsh/custom/plugins/oc
 
 you can edit your ~/.zshrc and add `oc` to the `plugins` variable like for example :
 


### PR DESCRIPTION
the current README places the oc completions in the wrong location:

~/.oh-my-zsh/custom/oc

Should be
~/.oh-my-zsh/custom/plugins/oc
